### PR TITLE
Rename Cloudflare Rocket Loader to Cloudflare Transform via URL

### DIFF
--- a/http/miscellaneous/cloudflare-rocketloader-htmli.yaml
+++ b/http/miscellaneous/cloudflare-rocketloader-htmli.yaml
@@ -1,15 +1,14 @@
-id: cloudflare-rocketloader-htmli
+id: cloudflare-rocketloader-image-injection
 
 info:
-  name: Cloudflare Rocket Loader - HTML Injection
+  name: Cloudflare Transform via URL - Image Injection
   author: j3ssie
   severity: unknown
   description: |
-    The Rocket Loader feature in Cloudflare allow attackers to inject arbitrary HTML into the website. This can be used to perform various attacks such as phishing, defacement, etc.
-  remediation: Disable the rocket loader or Add a CSP header to fix this issue.
+    Transform via URL feature in Cloudflare allow attackers to show arbitrary images to the visitor of a crafted URL on the website. This can be used to perform various attacks such as phishing, defacement, etc.
+  remediation: Disable Images → Transformations → “Resize from any origin” setting in Cloudflare console.
   reference:
-    - https://developers.cloudflare.com/speed/optimization/content/rocket-loader/enable/
-    - https://developers.cloudflare.com/fundamentals/reference/policies-compliances/content-security-policies/#product-requirements
+    - https://developers.cloudflare.com/images/transform-images/transform-via-url/
   metadata:
     verified: true
     max-request: 1


### PR DESCRIPTION
### Template / PR Information

This template in fact does not detect Rocket Loader as previously stated, but another Cloudflare feature, Transform via URL.
- References: https://developers.cloudflare.com/images/transform-images/transform-via-url/ that displays the same format of URL than the one that is scanned by this template.

The point was already raised by @smcgivern in the original PR: https://github.com/projectdiscovery/nuclei-templates/pull/9269#discussion_r1530252607


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)